### PR TITLE
refactor: remove extraneous framework namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,12 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"OpenSdk\\Framework\\": "src/"
+			"OpenSdk\\": "src/"
 		}
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"OpenSdk\\Framework\\Tests\\": "tests/"
+			"OpenSdk\\Tests\\": "tests/"
 		}
 	},
 	"scripts": {

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Client;
+namespace OpenSdk\Client;
 
-use OpenSdk\Framework\Middleware\MiddlewareInterface;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
+use OpenSdk\Middleware\MiddlewareInterface;
+use OpenSdk\Resource\Factory as ResourceFactory;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\RequestInterface as Response;
 
@@ -16,8 +16,8 @@ abstract class Client extends Container
 	{
 		$this->setHttpClient(new \Http\Adapter\Guzzle6\Client);
 		$this->setHttpFactory(new \Http\Message\MessageFactory\GuzzleMessageFactory);
-		$this->setMiddlewareStack(new \OpenSdk\Framework\Middleware\RelayStack);
-		$this->setResourceDecoder(new \OpenSdk\Framework\Resource\Decoder\JsonDecoder);
+		$this->setMiddlewareStack(new \OpenSdk\Middleware\RelayStack);
+		$this->setResourceDecoder(new \OpenSdk\Resource\Decoder\JsonDecoder);
 	}
 
 	/**

--- a/src/Client/ClientAwareInterface.php
+++ b/src/Client/ClientAwareInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Client;
+namespace OpenSdk\Client;
 
 interface ClientAwareInterface
 {

--- a/src/Client/ClientAwareTrait.php
+++ b/src/Client/ClientAwareTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Client;
+namespace OpenSdk\Client;
 
 trait ClientAwareTrait
 {

--- a/src/Client/Container.php
+++ b/src/Client/Container.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace OpenSdk\Framework\Client;
+namespace OpenSdk\Client;
 
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory as HttpFactory;
-use OpenSdk\Framework\Middleware\StackInterface as MiddlewareStack;
-use OpenSdk\Framework\Resource\DecoderInterface as ResourceDecoder;
+use OpenSdk\Middleware\StackInterface as MiddlewareStack;
+use OpenSdk\Resource\DecoderInterface as ResourceDecoder;
 
 abstract class Container
 {

--- a/src/Client/RestClient.php
+++ b/src/Client/RestClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Client;
+namespace OpenSdk\Client;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;

--- a/src/Exception/DecoderException.php
+++ b/src/Exception/DecoderException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Exception;
+namespace OpenSdk\Exception;
 
-use OpenSdk\Framework\Resource\DecoderInterface as ResourceDecoder;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
+use OpenSdk\Resource\DecoderInterface as ResourceDecoder;
+use OpenSdk\Resource\Factory as ResourceFactory;
 use Throwable;
 
 class DecoderException extends ResourceException

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Exception;
+namespace OpenSdk\Exception;
 
 use Psr\Http\Message\RequestInterface as Request;
 use RuntimeException;

--- a/src/Exception/ResourceException.php
+++ b/src/Exception/ResourceException.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OpenSdk\Framework\Exception;
+namespace OpenSdk\Exception;
 
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
+use OpenSdk\Resource\Factory as ResourceFactory;
 use Throwable;
 
 class ResourceException extends ResponseException

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Exception;
+namespace OpenSdk\Exception;
 
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;

--- a/src/Exception/SdkException.php
+++ b/src/Exception/SdkException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Exception;
+namespace OpenSdk\Exception;
 
 interface SdkException
 {

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Middleware;
+namespace OpenSdk\Middleware;
 
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;

--- a/src/Middleware/RelayStack.php
+++ b/src/Middleware/RelayStack.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Middleware;
+namespace OpenSdk\Middleware;
 
-use OpenSdk\Framework\Client\ClientAwareInterface;
-use OpenSdk\Framework\Client\ClientAwareTrait;
+use OpenSdk\Client\ClientAwareInterface;
+use OpenSdk\Client\ClientAwareTrait;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use Relay\Runner as RelayRunner;

--- a/src/Middleware/SendRequestMiddleware.php
+++ b/src/Middleware/SendRequestMiddleware.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Middleware;
+namespace OpenSdk\Middleware;
 
-use OpenSdk\Framework\Client\ClientAwareInterface;
-use OpenSdk\Framework\Client\ClientAwareTrait;
+use OpenSdk\Client\ClientAwareInterface;
+use OpenSdk\Client\ClientAwareTrait;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 

--- a/src/Middleware/StackInterface.php
+++ b/src/Middleware/StackInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OpenSdk\Framework\Middleware;
+namespace OpenSdk\Middleware;
 
-use OpenSdk\Framework\Client\ClientAwareInterface as ClientAware;
+use OpenSdk\Client\ClientAwareInterface as ClientAware;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 

--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Resource;
+namespace OpenSdk\Resource;
 
 use ArrayAccess;
 use ArrayIterator;

--- a/src/Resource/Decoder/JsonDecoder.php
+++ b/src/Resource/Decoder/JsonDecoder.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Resource\Decoder;
+namespace OpenSdk\Resource\Decoder;
 
-use OpenSdk\Framework\Exception\DecoderException;
-use OpenSdk\Framework\Resource\DecoderInterface;
-use OpenSdk\Framework\Resource\Factory;
+use OpenSdk\Exception\DecoderException;
+use OpenSdk\Resource\DecoderInterface;
+use OpenSdk\Resource\Factory;
 
 class JsonDecoder implements DecoderInterface
 {

--- a/src/Resource/DecoderInterface.php
+++ b/src/Resource/DecoderInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OpenSdk\Framework\Resource;
+namespace OpenSdk\Resource;
 
-use OpenSdk\Framework\Exception\DecoderException;
+use OpenSdk\Exception\DecoderException;
 
 interface DecoderInterface
 {

--- a/src/Resource/Factory.php
+++ b/src/Resource/Factory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Resource;
+namespace OpenSdk\Resource;
 
-use OpenSdk\Framework\Client\ClientAwareInterface;
-use OpenSdk\Framework\Client\ClientAwareTrait;
-use OpenSdk\Framework\Exception\ResourceException;
+use OpenSdk\Client\ClientAwareInterface;
+use OpenSdk\Client\ClientAwareTrait;
+use OpenSdk\Exception\ResourceException;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSdk\Framework\Resource;
+namespace OpenSdk\Resource;
 
 class Model extends Collection
 {

--- a/tests/Client/ClientAwareTraitTest.php
+++ b/tests/Client/ClientAwareTraitTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Client;
+namespace OpenSdk\Tests\Client;
 
-use OpenSdk\Framework\Client\Client;
-use OpenSdk\Framework\Client\ClientAwareTrait;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Client\Client;
+use OpenSdk\Client\ClientAwareTrait;
+use OpenSdk\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject as PHPUnitMock;
 
 class ClientAwareTraitTest extends TestCase

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Client;
+namespace OpenSdk\Tests\Client;
 
-use OpenSdk\Framework\Client\Client;
-use OpenSdk\Framework\Middleware\MiddlewareInterface;
-use OpenSdk\Framework\Middleware\StackInterface;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Client\Client;
+use OpenSdk\Middleware\MiddlewareInterface;
+use OpenSdk\Middleware\StackInterface;
+use OpenSdk\Resource\Factory as ResourceFactory;
+use OpenSdk\Tests\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/Client/ContainerTest.php
+++ b/tests/Client/ContainerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Client;
+namespace OpenSdk\Tests\Client;
 
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory as HttpFactory;
-use OpenSdk\Framework\Client\Container;
-use OpenSdk\Framework\Middleware\StackInterface as MiddlewareStack;
-use OpenSdk\Framework\Resource\DecoderInterface as ResourceDecoder;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Client\Container;
+use OpenSdk\Middleware\StackInterface as MiddlewareStack;
+use OpenSdk\Resource\DecoderInterface as ResourceDecoder;
+use OpenSdk\Tests\TestCase;
 
 class ContainerTest extends TestCase
 {

--- a/tests/Client/RestClientTest.php
+++ b/tests/Client/RestClientTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Client;
+namespace OpenSdk\Tests\Client;
 
-use OpenSdk\Framework\Client\RestClient;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Client\RestClient;
+use OpenSdk\Tests\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 class RestClientTest extends TestCase

--- a/tests/Exception/DecoderExceptionTest.php
+++ b/tests/Exception/DecoderExceptionTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Exception;
+namespace OpenSdk\Tests\Exception;
 
-use OpenSdk\Framework\Exception\DecoderException;
-use OpenSdk\Framework\Exception\SdkException;
-use OpenSdk\Framework\Resource\DecoderInterface;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
-use OpenSdk\Framework\Tests\ExceptionTestCase;
+use OpenSdk\Exception\DecoderException;
+use OpenSdk\Exception\SdkException;
+use OpenSdk\Resource\DecoderInterface;
+use OpenSdk\Resource\Factory as ResourceFactory;
+use OpenSdk\Tests\ExceptionTestCase;
 
 class DecoderExceptionTest extends ExceptionTestCase
 {

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Exception;
+namespace OpenSdk\Tests\Exception;
 
-use OpenSdk\Framework\Exception\RequestException;
-use OpenSdk\Framework\Exception\SdkException;
-use OpenSdk\Framework\Tests\ExceptionTestCase;
+use OpenSdk\Exception\RequestException;
+use OpenSdk\Exception\SdkException;
+use OpenSdk\Tests\ExceptionTestCase;
 
 class RequestExceptionTest extends ExceptionTestCase
 {

--- a/tests/Exception/ResourceExceptionTest.php
+++ b/tests/Exception/ResourceExceptionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Exception;
+namespace OpenSdk\Tests\Exception;
 
-use OpenSdk\Framework\Exception\ResourceException;
-use OpenSdk\Framework\Exception\SdkException;
-use OpenSdk\Framework\Tests\ExceptionTestCase;
+use OpenSdk\Exception\ResourceException;
+use OpenSdk\Exception\SdkException;
+use OpenSdk\Tests\ExceptionTestCase;
 
 class ResourceExceptionTest extends ExceptionTestCase
 {

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Exception;
+namespace OpenSdk\Tests\Exception;
 
-use OpenSdk\Framework\Exception\ResponseException;
-use OpenSdk\Framework\Exception\SdkException;
-use OpenSdk\Framework\Tests\ExceptionTestCase;
+use OpenSdk\Exception\ResponseException;
+use OpenSdk\Exception\SdkException;
+use OpenSdk\Tests\ExceptionTestCase;
 
 class ResponseExceptionTest extends ExceptionTestCase
 {

--- a/tests/ExceptionTestCase.php
+++ b/tests/ExceptionTestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OpenSdk\Framework\Tests;
+namespace OpenSdk\Tests;
 
-use OpenSdk\Framework\Exception\SdkException;
+use OpenSdk\Exception\SdkException;
 
 abstract class ExceptionTestCase extends TestCase
 {

--- a/tests/Middleware/RelayStackTest.php
+++ b/tests/Middleware/RelayStackTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Middleware;
+namespace OpenSdk\Tests\Middleware;
 
 use Http\Client\HttpClient;
-use OpenSdk\Framework\Client\ClientAwareInterface;
-use OpenSdk\Framework\Middleware\MiddlewareInterface;
-use OpenSdk\Framework\Middleware\RelayStack;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Client\ClientAwareInterface;
+use OpenSdk\Middleware\MiddlewareInterface;
+use OpenSdk\Middleware\RelayStack;
+use OpenSdk\Tests\TestCase;
 
 class RelayStackTest extends TestCase
 {

--- a/tests/Middleware/SendRequestMiddlewareTest.php
+++ b/tests/Middleware/SendRequestMiddlewareTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Middleware;
+namespace OpenSdk\Tests\Middleware;
 
 use Http\Client\HttpClient;
-use OpenSdk\Framework\Middleware\MiddlewareInterface;
-use OpenSdk\Framework\Middleware\SendRequestMiddleware;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Middleware\MiddlewareInterface;
+use OpenSdk\Middleware\SendRequestMiddleware;
+use OpenSdk\Tests\TestCase;
 
 class SendRequestMiddlewareTest extends TestCase
 {

--- a/tests/Resource/CollectionTest.php
+++ b/tests/Resource/CollectionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource;
+namespace OpenSdk\Tests\Resource;
 
-use OpenSdk\Framework\Resource\Collection;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Resource\Collection;
+use OpenSdk\Tests\TestCase;
 
 class CollectionTest extends TestCase
 {

--- a/tests/Resource/Decoder/JsonDecoderTest.php
+++ b/tests/Resource/Decoder/JsonDecoderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource\Decoder;
+namespace OpenSdk\Tests\Resource\Decoder;
 
-use OpenSdk\Framework\Exception\DecoderException;
-use OpenSdk\Framework\Resource\Decoder\JsonDecoder;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Exception\DecoderException;
+use OpenSdk\Resource\Decoder\JsonDecoder;
+use OpenSdk\Tests\TestCase;
 use Psr\Http\Message\StreamInterface;
 
 class JsonDecoderTest extends TestCase

--- a/tests/Resource/FactoryTest.php
+++ b/tests/Resource/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource;
+namespace OpenSdk\Tests\Resource;
 
-use OpenSdk\Framework\Exception\ResourceException;
-use OpenSdk\Framework\Resource\Collection;
-use OpenSdk\Framework\Resource\DecoderInterface;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
-use OpenSdk\Framework\Resource\Model;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Exception\ResourceException;
+use OpenSdk\Resource\Collection;
+use OpenSdk\Resource\DecoderInterface;
+use OpenSdk\Resource\Factory as ResourceFactory;
+use OpenSdk\Resource\Model;
+use OpenSdk\Tests\TestCase;
 
 class FactoryTest extends TestCase
 {

--- a/tests/Resource/ModelCastStub.php
+++ b/tests/Resource/ModelCastStub.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource;
+namespace OpenSdk\Tests\Resource;
 
 use DateTime;
-use OpenSdk\Framework\Resource\Model;
+use OpenSdk\Resource\Model;
 
 /**
  * @property mixed $testAny

--- a/tests/Resource/ModelTest.php
+++ b/tests/Resource/ModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource;
+namespace OpenSdk\Tests\Resource;
 
 use DateTime;
-use OpenSdk\Framework\Resource\Collection;
-use OpenSdk\Framework\Resource\Model;
-use OpenSdk\Framework\Tests\TestCase;
+use OpenSdk\Resource\Collection;
+use OpenSdk\Resource\Model;
+use OpenSdk\Tests\TestCase;
 
 class ModelTest extends TestCase
 {

--- a/tests/Resource/NestedModelStub.php
+++ b/tests/Resource/NestedModelStub.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OpenSdk\Framework\Tests\Resource;
+namespace OpenSdk\Tests\Resource;
 
-use OpenSdk\Framework\Resource\Model;
+use OpenSdk\Resource\Model;
 
 /**
  * @property string $nested

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSdk\Framework\Tests;
+namespace OpenSdk\Tests;
 
-use OpenSdk\Framework\Client\Client;
-use OpenSdk\Framework\Resource\Factory as ResourceFactory;
+use OpenSdk\Client\Client;
+use OpenSdk\Resource\Factory as ResourceFactory;
 use PHPUnit\Framework\MockObject\MockObject as PHPUnitMock;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since everything is put into a "category" folder the framework namespace becomes extraneous.