### PR TITLE
fix: extend throwable interface from sdk exception

### DIFF
--- a/src/Exception/SdkException.php
+++ b/src/Exception/SdkException.php
@@ -2,7 +2,7 @@
 
 namespace OpenSdk\Exception;
 
-interface SdkException
+interface SdkException extends \Throwable
 {
 	//
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This makes sure that every SDK exception can be thrown and used as proper exception.