### PR TITLE
feature/open-sdk-phpstan-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	"require-dev": {
 		"codacy/coverage": "^1.4.1",
 		"guzzlehttp/psr7": "^1.4.2",
+		"open-sdk/framework-phpstan": "^0.1.0",
 		"php-http/guzzle6-adapter": "^1.1.1",
 		"php-http/message": "^1.6.0",
 		"phpstan/phpstan": "^0.9.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+	- vendor/open-sdk/framework-phpstan/extension.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 	- vendor/phpstan/phpstan-phpunit/strictRules.neon

--- a/tests/Resource/ManagerTest.php
+++ b/tests/Resource/ManagerTest.php
@@ -194,10 +194,7 @@ class ManagerTest extends TestCase
 	{
 		$manager = $this->createManager(['data' => ['name' => 'Cedric']])->setUnwrap('data');
 
-		/** @var UserModel */
-		$user = $manager->asModel(UserModel::class);
-
-		$this->assertSame('Cedric', $user->getName());
+		$this->assertSame('Cedric', $manager->asModel(UserModel::class)->getName());
 	}
 
 	public function testAsCollectionReturnsCollectionWithModels()


### PR DESCRIPTION
## Description

This implements the freshly created PHPStan extension. It takes the need for the "annoying" `@var` statement when casting different model types using `asModel`.