### PR TITLE
fix/resource-validation-message

### DIFF
--- a/src/Resource/Object/Model.php
+++ b/src/Resource/Object/Model.php
@@ -103,10 +103,12 @@ class Model extends Element
 	 */
 	public static function validate(string $type): string
 	{
-		if (is_a($type, static::class, true)) {
+		$class = static::class;
+
+		if (is_a($type, $class, true)) {
 			return $type;
 		}
 
-		throw new ResourceException("Class '{$type}' is not a model.");
+		throw new ResourceException("Class '{$type}' is not a '{$class}'.");
 	}
 }


### PR DESCRIPTION
## Description

This updates the exception message thrown when validating class types for resource models. The feature was added to the model to allow extended models being able to validate too. Only the message was never updated with this feature.